### PR TITLE
Update _sidebar.scss

### DIFF
--- a/src/assets/scss/components/_sidebar.scss
+++ b/src/assets/scss/components/_sidebar.scss
@@ -88,7 +88,7 @@
                 }
             }
             &.active {
-                .sidebar-link {
+                >.sidebar-link {
                     background-color: $primary;
                     span {
                         color: #fff;


### PR DESCRIPTION
This change corrects formatting when you have multiple levels of grouping in the sidebar (groups inside groups). Currently if a you have a <li> with the classes "sidebar-item active has-sub", then any levels of groups beneath it will look active. After this change is applied, only the immediate descendants will look active.