### PR TITLE
Fix spelling error, fix table-responsive class help text

### DIFF
--- a/src/assets/scss/components/_sidebar.scss
+++ b/src/assets/scss/components/_sidebar.scss
@@ -88,7 +88,7 @@
                 }
             }
             &.active {
-                .sidebar-link {
+                >.sidebar-link {
                     background-color: $primary;
                     span {
                         color: #fff;

--- a/src/table.html
+++ b/src/table.html
@@ -987,13 +987,11 @@
                         <div class="card-body">
                             <p>Responsive tables allow tables to be scrolled horizontally with ease. Make any table
                                 responsive across all
-                                viewports by adding <code class="highlighter-rouge">.table-responsive</code> class on
-                                <code class="highlighter-rouge">.table</code>. Or, pick a maximum breakpoint with which
-                                to
-                                have a responsive
+                                viewports by adding a div with the class <code class="highlighter-rouge">.table-responsive</code>
+								around the table. Or, pick a maximum breakpoint with which to have a responsive
                                 table up to by adding <code
                                     class="highlighter-rouge"> .table-responsive{-sm|-md|-lg|-xl}</code>. Read full
-                                documnetation <a
+                                documentation <a
                                     href="https://getbootstrap.com/docs/4.3/content/tables/#responsive-tables"
                                     target="_blank">here.</a>
                             </p>

--- a/src/table.html
+++ b/src/table.html
@@ -987,11 +987,13 @@
                         <div class="card-body">
                             <p>Responsive tables allow tables to be scrolled horizontally with ease. Make any table
                                 responsive across all
-                                viewports by adding a div with the class <code class="highlighter-rouge">.table-responsive</code>
-								around the table. Or, pick a maximum breakpoint with which to have a responsive
+                                viewports by adding <code class="highlighter-rouge">.table-responsive</code> class on
+                                <code class="highlighter-rouge">.table</code>. Or, pick a maximum breakpoint with which
+                                to
+                                have a responsive
                                 table up to by adding <code
                                     class="highlighter-rouge"> .table-responsive{-sm|-md|-lg|-xl}</code>. Read full
-                                documentation <a
+                                documnetation <a
                                     href="https://getbootstrap.com/docs/4.3/content/tables/#responsive-tables"
                                     target="_blank">here.</a>
                             </p>


### PR DESCRIPTION
Fixed spelling error of "documentation".
Fixed .table-responsive should be added to surrounding div, not to the table itself.

https://getbootstrap.com/docs/5.0/content/tables/