### PR TITLE
fix: updating $theme-color-rgb css variable.

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -135,6 +135,10 @@ $theme-colors: (
 );
 // scss-docs-end theme-colors-map
 
+// scss-docs-start theme-colors-rgb
+$theme-colors-rgb: map-loop($theme-colors, to-rgb, "$value") !default;
+// scss-docs-end theme-colors-rgb
+
 // The contrast ratio to reach against white, to determine if color changes from "light" to "dark". Acceptable values for WCAG 2.0 are 3, 4.5 and 7.
 // See https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast
 $min-contrast-ratio:   4.5;


### PR DESCRIPTION
Hello, I found following CSS variables not updated due theme colors and have BS default values.

```
--bs-primary-rgb: 13,110,253;
--bs-secondary-rgb: 108,117,125;
--bs-success-rgb: 25,135,84;
--bs-info-rgb: 13,202,240;
--bs-warning-rgb: 255,193,7;
--bs-danger-rgb: 220,53,69;
--bs-light-rgb: 248,249,250;
--bs-dark-rgb: 33,37,41;
--bs-white-rgb: 255,255,255;
--bs-black-rgb: 0,0,0;
--bs-body-color-rgb: 96,112,128;
--bs-body-bg-rgb: 242,247,255;
```
Impact of that theme colors not work properly. For example bg-primary. You can check it [mazer/dist/component-modal.html](https://github.com/zuramai/mazer/blob/main/dist/component-modal.html). Please find the attachment image.

![image](https://user-images.githubusercontent.com/1506103/154911283-fd45511d-e5ab-44f9-a525-728482573798.png)
