### PR TITLE
Prevent sidebar from throwing errors when there is no active item

### DIFF
--- a/src/assets/js/components/sidebar.js
+++ b/src/assets/js/components/sidebar.js
@@ -46,7 +46,7 @@ class Sidebar {
     }
 
     // Scroll into active sidebar
-    setTimeout(() => document.querySelector('.sidebar-item.active').scrollIntoView(false), 100);
+    setTimeout(() => document.querySelector('.sidebar-item.active')?.scrollIntoView(false), 100);
 
     // check responsive
     this.onFirstLoad();


### PR DESCRIPTION
I got some errors in my frontend error handler related to the sidebar.
In some situations I don't have an active menu item.