### PR TITLE
Autoscroll when opening submenus in sidebar

### DIFF
--- a/src/assets/js/components/sidebar.js
+++ b/src/assets/js/components/sidebar.js
@@ -46,7 +46,7 @@ class Sidebar {
     }
 
     // Scroll into active sidebar
-    setTimeout(() => document.querySelector('.sidebar-item.active').scrollIntoView(false), 100);
+    setTimeout(() => document.querySelector('.sidebar-item.active')?.scrollIntoView(false), 100);
 
     // check responsive
     this.onFirstLoad();

--- a/src/assets/js/components/sidebar.js
+++ b/src/assets/js/components/sidebar.js
@@ -25,7 +25,7 @@ class Sidebar {
     let sidebarItems = document.querySelectorAll('.sidebar-item.has-sub');
     for(var i = 0; i < sidebarItems.length; i++) {
         let sidebarItem = sidebarItems[i];
-      sidebarItems[i].querySelector('.sidebar-link').addEventListener('click', function(e) {
+      sidebarItems[i].querySelector('.sidebar-link').addEventListener('click', (e) => {
             e.preventDefault();
             
             let submenu = sidebarItem.querySelector('.submenu');
@@ -33,7 +33,7 @@ class Sidebar {
 
             if( submenu.style.display == "none" ) submenu.classList.add('active')
             else submenu.classList.remove('active')
-            slideToggle(submenu, 300)
+            slideToggle(submenu, 300, () => this.forceElementVisibility(sidebarItem))
         })
     }
 
@@ -140,6 +140,24 @@ class Sidebar {
       body.style.overflowY = sidebarState ? 'hidden' : 'auto';
     } else {
       body.style.overflowY = active ? 'auto' : 'hidden';
+    }
+  }
+
+  isElementInViewport(el) {
+    var rect = el.getBoundingClientRect();
+  
+    return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <=
+        (window.innerHeight || document.documentElement.clientHeight) &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+  }
+  
+  forceElementVisibility(el) {
+    if (!this.isElementInViewport(el)) {
+      el.scrollIntoView(false);
     }
   }
 }


### PR DESCRIPTION
If the user opens a submenu in the sidebar located at the bottom of the viewport, he will need to manually the opening menu into view.

I implemented a quick autoscroll functionality which scrolls the submenu into view after opening it.
This is not an optimal solution as it has to wait for the opening animation to complete.

The `slideToggle` function is hard to modify as the function code is minified.