### PR TITLE
Only force white caret on button dropdowns

### DIFF
--- a/dist/layout-vertical-navbar.html
+++ b/dist/layout-vertical-navbar.html
@@ -427,9 +427,9 @@
                         <div class="collapse navbar-collapse" id="navbarSupportedContent">
                             <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                                 <li class="nav-item dropdown me-1">
-                                    <a class="nav-link active dropdown-toggle" href="#" data-bs-toggle="dropdown"
+                                    <a class="nav-link active dropdown-toggle text-gray-600" href="#" data-bs-toggle="dropdown"
                                         aria-expanded="false">
-                                        <i class='bi bi-envelope bi-sub fs-4 text-gray-600'></i>
+                                        <i class='bi bi-envelope bi-sub fs-4'></i>
                                     </a>
                                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuButton">
                                         <li>
@@ -439,9 +439,9 @@
                                     </ul>
                                 </li>
                                 <li class="nav-item dropdown me-3">
-                                    <a class="nav-link active dropdown-toggle" href="#" data-bs-toggle="dropdown"
+                                    <a class="nav-link active dropdown-toggle text-gray-600" href="#" data-bs-toggle="dropdown"
                                         aria-expanded="false">
-                                        <i class='bi bi-bell bi-sub fs-4 text-gray-600'></i>
+                                        <i class='bi bi-bell bi-sub fs-4'></i>
                                     </a>
                                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuButton">
                                         <li>

--- a/src/assets/js/components/sidebar.js
+++ b/src/assets/js/components/sidebar.js
@@ -46,7 +46,7 @@ class Sidebar {
     }
 
     // Scroll into active sidebar
-    setTimeout(() => document.querySelector('.sidebar-item.active').scrollIntoView(false), 100);
+    setTimeout(() => document.querySelector('.sidebar-item.active')?.scrollIntoView(false), 100);
 
     // check responsive
     this.onFirstLoad();

--- a/src/assets/scss/components/_dropdowns.scss
+++ b/src/assets/scss/components/_dropdowns.scss
@@ -1,4 +1,4 @@
-.btn .dropdown-toggle:after {
+.btn:not(.btn-light):not([class^="btn-outline-"]) .dropdown-toggle:after {
     color: #fff;
 }
 .dropdown-menu-large {

--- a/src/assets/scss/components/_dropdowns.scss
+++ b/src/assets/scss/components/_dropdowns.scss
@@ -1,4 +1,4 @@
-.dropdown-toggle:after {
+.btn .dropdown-toggle:after {
     color: #fff;
 }
 .dropdown-menu-large {


### PR DESCRIPTION
The dropdown caret color is set to white on all dropdowns.
Negative implications of this can be observed in the "Vertical Navbar" demo.

![Vertical Navbar](https://user-images.githubusercontent.com/1611565/157058672-e5b9285a-cad9-45ab-8684-868e60714ad2.png)

After looking through the code I think all dropdown examples use buttons where the white color works great.

I changed the definition to only affect caret color in buttons.
Light buttons and outline button should be excluded as well imho.
