### PR TITLE
Fixed nav being hidden if resized after being clicked on in horizontal-layout

### DIFF
--- a/dist/assets/js/pages/horizontal-layout.js
+++ b/dist/assets/js/pages/horizontal-layout.js
@@ -15,6 +15,7 @@ window.addEventListener('resize',(event) => {
 
 function checkWindowSize() {
     if(window.innerWidth < 1200) listener()
+    if(window.innerWidth > 1200) document.querySelector('.main-navbar').style.display = ""
 }
 
 function listener() {


### PR DESCRIPTION
if a user makes the screen smaller than 1200, they can click the "burger" button to open and close the nav. if they then enlarge the window after closing it, the nav will still be hidden. this pr fixes that by removing the `display: none` when being resized above 1200