### PR TITLE
Theme handling improvements

### DIFF
--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/assets/js/components/dark.js
+++ b/src/assets/js/components/dark.js
@@ -18,12 +18,11 @@ export function setTheme(theme, dontPersist = false) {
   document.body.className = document.body.className.replace(THEME_REGEX, "");
   console.log("change theme to ", theme);
   document.body.classList.add(theme);
+  toggler.checked = theme == "theme-dark";
 
   if (!dontPersist) {
     localStorage.setItem(THEME_KEY, theme);
   }
-  
-  toggler.checked = theme == "theme-dark";
 }
 
 toggler.addEventListener("input", (e) => {

--- a/src/assets/js/components/dark.js
+++ b/src/assets/js/components/dark.js
@@ -1,50 +1,56 @@
-let bodyClass = document.body.classList
-let toggler = document.getElementById("toggle-dark")
+const THEME_KEY = "theme";
+const THEME_REGEX = /\btheme-[a-z0-9]+\b/g;
+const toggler = document.getElementById("toggle-dark");
 
-export function toggleTheme() {
-    if(bodyClass.contains("theme-dark"))
-        bodyClass.remove("theme-dark")
-    else 
-        bodyClass.add("theme-dark")
+export function toggleDarkTheme() {
+  setTheme(
+    document.body.classList.contains("theme-dark")
+      ? "theme-light"
+      : "theme-dark"
+  );
 }
 
 /**
  * Set theme for mazer
- * @param {"theme-dark"|"theme-light"} theme 
+ * @param {"theme-dark"|"theme-light"} theme
  */
-export function setTheme(theme) {
-    document.body.className = ""
-    console.log("change theme to ", theme);
-    bodyClass.add(theme)
-    localStorage.setItem(THEME_KEY, theme)
-    toggler.checked = theme == "theme-dark"
+export function setTheme(theme, dontPersist = false) {
+  document.body.className = document.body.className.replace(THEME_REGEX, "");
+  console.log("change theme to ", theme);
+  document.body.classList.add(theme);
+
+  if (!dontPersist) {
+    localStorage.setItem(THEME_KEY, theme);
+  }
+  
+  toggler.checked = theme == "theme-dark";
 }
 
-toggler.addEventListener('input', e => {
-    setTheme(e.target.checked ? "theme-dark" : "theme-light")
-})
+toggler.addEventListener("input", (e) => {
+  setTheme(e.target.checked ? "theme-dark" : "theme-light");
+});
 
-window.onload = () => {
-    console.log("Dark Loaded");
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("Dark Loaded");
 
-    if(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-    
-        if(localStorage.getItem(THEME_KEY) == "theme-light") {
-            return setTheme("theme-light")
-        } 
-        
-        setTheme("theme-dark")
-    } else {
-        
-        if(localStorage.getItem(THEME_KEY) == "theme-dark") {
-            return setTheme("theme-dark")
-        } 
+  //If the user manually set a theme, we'll load that
+  let storedTheme;
+  if ((storedTheme = localStorage.getItem(THEME_KEY))) {
+    return setTheme(storedTheme);
+  }
 
-        setTheme("theme-light")
+  //Detect if the user set his preferred color scheme to dark
+  if (!window.matchMedia) {
+    return;
+  }
 
-    }
-}
+  //Media query to detect dark preference
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
-const THEME_KEY = "theme"
+  //Register change listener
+  mediaQuery.addEventListener("change", (e) =>
+    setTheme(e.matches ? "theme-dark" : "theme-light", true)
+  );
 
-
+  return setTheme(mediaQuery.matches ? "theme-dark" : "theme-light", true);
+});

--- a/src/assets/js/extensions/tinymce.js
+++ b/src/assets/js/extensions/tinymce.js
@@ -1,14 +1,33 @@
 import tinymce from "tinymce";
 
- /* Default icons are required for TinyMCE 5.3 or above */
- import 'tinymce/icons/default';
+/* Default icons are required for TinyMCE 5.3 or above */
+import "tinymce/icons/default";
 
- /* A theme is also required */
- import 'tinymce/themes/silver';
+/* A theme is also required */
+import "tinymce/themes/silver";
 
- 
- /* Import plugins */
- import 'tinymce/plugins/code';
- 
-tinymce.init({ selector: '#default' });
-tinymce.init({ selector: '#dark', toolbar: 'undo redo styleselect bold italic alignleft aligncenter alignright bullist numlist outdent indent code', plugins: 'code' });
+/* Import plugins */
+import "tinymce/plugins/code";
+
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("initing", document.body.classList.contains("theme-dark"));
+
+  const themeOptions = document.body.classList.contains("theme-dark")
+    ? {
+        skin: "oxide-dark",
+        content_css: "dark",
+      }
+    : {
+        skin: "oxide",
+        content_css: "default",
+      };
+
+  tinymce.init({ selector: "#default", ...themeOptions });
+  tinymce.init({
+    selector: "#dark",
+    toolbar:
+      "undo redo styleselect bold italic alignleft aligncenter alignright bullist numlist outdent indent code",
+    plugins: "code",
+    ...themeOptions,
+  });
+});

--- a/src/assets/scss/pages/auth.scss
+++ b/src/assets/scss/pages/auth.scss
@@ -38,7 +38,7 @@ body {
     }
 }
 
-.theme-dark {
+body.theme-dark {
     @import "../themes/dark/variables-dark";
     @debug $page-auth-right-bg;
 

--- a/src/assets/scss/pages/email.scss
+++ b/src/assets/scss/pages/email.scss
@@ -576,7 +576,7 @@
     }
 }
 
-.theme-dark {
+body.theme-dark {
     .email-application .content-area-wrapper {
         border: 1px solid #2a2f3e;
     }
@@ -629,7 +629,7 @@
         border: 1px solid #373752;
     }
 
-    .theme-dark .form-check-input {
+    body.theme-dark .form-check-input {
         background-color: #151521;
         border: 2px solid #435ebe;
     }

--- a/src/assets/scss/pages/error.scss
+++ b/src/assets/scss/pages/error.scss
@@ -12,7 +12,7 @@
         margin-top: 3rem;
     }
 }
-.theme-dark {
+body.theme-dark {
     #error {
         @import "../themes/dark/variables-dark";
         background-color: $page-error-bg;

--- a/src/assets/scss/themes/dark/_root.scss
+++ b/src/assets/scss/themes/dark/_root.scss
@@ -1,4 +1,4 @@
-.theme-dark {
+body.theme-dark {
     // Note: Custom variable values only support SassScript inside `#{}`.
   
     // Colors

--- a/src/assets/scss/themes/dark/app-dark.scss
+++ b/src/assets/scss/themes/dark/app-dark.scss
@@ -6,7 +6,7 @@
 @import "~bootstrap/scss/mixins";
 @import "./root";
 
-.theme-dark {
+body.theme-dark {
     // Bootstrap 
     @import "~bootstrap/scss/utilities";
     @import "~bootstrap/scss/reboot";

--- a/src/layouts/master.html
+++ b/src/layouts/master.html
@@ -38,8 +38,8 @@
             </footer>
         </div>
     </div>
-    {% block js %}{% endblock %}
     <script src="assets/js/app.js"></script>
+    {% block js %}{% endblock %}
 </body>
 
 </html>

--- a/src/layouts/rtl.html
+++ b/src/layouts/rtl.html
@@ -37,8 +37,8 @@
             </footer>
         </div>
     </div>
-    {% block js %}{% endblock %}
     <script src="assets/js/app.js"></script>
+    {% block js %}{% endblock %}
 </body>
 
 </html>

--- a/src/layouts/vertical-navbar.html
+++ b/src/layouts/vertical-navbar.html
@@ -108,8 +108,8 @@
             </div>
         </div>
     </div>
-    {% block js %}{% endblock %}
     <script src="assets/js/app.js"></script>
+    {% block js %}{% endblock %}
 </body>
 
 </html>


### PR DESCRIPTION
Some improvements for dark theme support

- Use the DOMContentLoaded event instead of "load" because the theme will apply while the site is still potentially loading resources. This prevents some "flickering" from light to dark on page change.
- Apply theme based on the local storage setting. If the setting is missing (and only then), respect "prefers-color-scheme" to set a theme, but skip persisting.
- Swaps the theme via a listener if prefers-color-scheme changes (if theme is not pinned)
-Apply dark theme stuff to body.theme-dark {} instead of .theme-dark {} only because the class name is pretty generic.
- Don't clear out body classes because users might use other classes on body. Instead, use regex to remove existing theme classes.
- Auto dark-theme for tinymce