### PR TITLE
FIX: for complying with the standards of bootstrap, the class 'card-t…

### DIFF
--- a/src/assets/scss/components/_card.scss
+++ b/src/assets/scss/components/_card.scss
@@ -45,9 +45,6 @@
     .card-content {
         position: relative;
     }
-    .card-title {
-        font-size: 1.2rem;
-    }
     .card-body {
         padding: $card-cap-padding-y $card-cap-padding-x;
     }


### PR DESCRIPTION
FIX: for complying with the standards of bootstrap, the class 'card-title' should not define a fixed font-size. The font-size is an attribute of the heading tags.