### PR TITLE
Capitalize placeholder text

### DIFF
--- a/src/component-dropdown.html
+++ b/src/component-dropdown.html
@@ -884,7 +884,7 @@ extends 'layouts/master.html' %} {% block content %}
                         type="email"
                         class="form-control"
                         id="exampleDropdownFormEmail1"
-                        placeholder="email"
+                        placeholder="Email"
                       />
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
Seeing the form password using capitalize text for placeholder and the form email is not using capitalize text i think is uncomfortable too seeing it xD