### PR TITLE
fix: case sensitive chartjs

### DIFF
--- a/src/ui-chart-chartjs.html
+++ b/src/ui-chart-chartjs.html
@@ -48,6 +48,6 @@
 {% endblock %}
 
 {% block js %}
-<script src="assets/extensions/chart.js/Chart.min.js"></script>
+<script src="assets/extensions/chart.js/chart.min.js"></script>
 <script src="assets/js/pages/ui-chartjs.js"></script>
 {% endblock %}


### PR DESCRIPTION
in page charts/chartjs, chart not showing, because there is an error in the chartjs file source caused by case sensitive