### PR TITLE
fix: google maps iframe width to 100%

### DIFF
--- a/src/ui-map-google-map.html
+++ b/src/ui-map-google-map.html
@@ -29,7 +29,7 @@
                     </div>
                     <div class="card-body">
                         <div class="googlemaps">
-                            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d126748.6091242787!2d107.57311654129782!3d-6.903273917028756!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x2e68e6398252477f%3A0x146a1f93d3e815b2!2sBandung%2C%20Bandung%20City%2C%20West%20Java!5e0!3m2!1sen!2sid!4v1633023222539!5m2!1sen!2sid" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+                            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d126748.6091242787!2d107.57311654129782!3d-6.903273917028756!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x2e68e6398252477f%3A0x146a1f93d3e815b2!2sBandung%2C%20Bandung%20City%2C%20West%20Java!5e0!3m2!1sen!2sid!4v1633023222539!5m2!1sen!2sid" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Overview
- Fix google maps iframe width to 100% at src/ui-map-google-map.html

## Before
<img width="1678" alt="Screen Shot 2022-10-03 at 09 26 10" src="https://user-images.githubusercontent.com/21275214/193491137-83aa146f-c861-44fd-b216-fa9da857b21a.png">

## After
<img width="1679" alt="Screen Shot 2022-10-03 at 09 26 26" src="https://user-images.githubusercontent.com/21275214/193491156-84851e82-90d6-47d5-9028-8ef19246911a.png">
