### PR TITLE
fix: import of functions.scss in bootstrap.scss

### DIFF
--- a/src/assets/scss/bootstrap.scss
+++ b/src/assets/scss/bootstrap.scss
@@ -7,6 +7,7 @@
 
 // scss-docs-start import-stack
 // Configuration
+@import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
 // Override variables
 @import "variables";


### PR DESCRIPTION
Hello,

I encountered a little problem with Webpack Encore (Provided with Symfony).

I found @import "~bootstrap/scss/functions"; not imported in bootstrap.scss.