### PR TITLE
docs: fix text highlighted on .avatar-content

### DIFF
--- a/src/extra-component-avatar.html
+++ b/src/extra-component-avatar.html
@@ -26,7 +26,7 @@
                 <h4 class="card-title">Default Avatar</h4>
             </div>
             <div class="card-body">
-                <p>Wrap your content with <code>.avatar</code> class and wrap your text in <code>.avatar</code>-content
+                <p>Wrap your content with <code>.avatar</code> class and wrap your text in <code>.avatar-content</code>
                     to create a avatar.You have to use inline
                     attributes to set height width of image in default avatar.</p>
                 <div class="avatar bg-primary me-3">


### PR DESCRIPTION
I have been fixed text highlighted class .avatar-content on docs

before: 
![image](https://user-images.githubusercontent.com/60420319/198497149-67e8f7c4-cf91-493f-960f-c8fa1d4df24b.png)
