### PR TITLE
fix: changed svg color value from #fff to white

### DIFF
--- a/src/assets/scss/components/_sidebar.scss
+++ b/src/assets/scss/components/_sidebar.scss
@@ -107,7 +107,7 @@
                     }
 
                     &.has-sub:after {
-                        content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9" style="fill:none;stroke:#fff;stroke-width:1"></polyline></svg>');
+                        content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9" style="fill:none;stroke:white;stroke-width:1"></polyline></svg>');
                     }
                 }
             }


### PR DESCRIPTION
The color value with # breaks building/minifying in symfony project with webpack-encore-bundle `Error: SvgoParserError: <input>:1:259: Unquoted attribute value`. Beyond that the value with # is an inconsistency as the other two values in line 85 and line 96 are `grey` and `white`.