### PR TITLE
Add Symfony 6.3 with latest Mazer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ npm run dev
 - [Adonisjs 5](https://github.com/afman42/mazer-adonisjs) by [@afman42](https://github.com/afman42/)
 - [Django](https://github.com/bimbims125/mazer-django) by [@bimbims125](https://github.com/bimbims125/)
 - [Flask](https://github.com/antheiz/mazer-flask) by [@antheiz](https://github.com/antheiz/)
-- [Symfony](https://github.com/jvl1v5/symfony-mazer) by [@jvl1v5](https://github.com/jvl1v5/)
 - [Symfony 6.3 (Mazer 2.1.0)](https://github.com/TheoD02/mazer-symfony-6.3/tree/mazer-2.1.0) by [@theod02](ttps://github.com/TheoD02)
 - [Spring-Thymeleaf](https://github.com/deyhay-enterprise/spring-project-mazer-template) by [@hi-rullah](https://github.com/hi-rullah)
 - [Ruby on Rails](https://github.com/noesya/mazer-rails) by [@noesya](https://github.com/noesya)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npm run dev
 - [Django](https://github.com/bimbims125/mazer-django) by [@bimbims125](https://github.com/bimbims125/)
 - [Flask](https://github.com/antheiz/mazer-flask) by [@antheiz](https://github.com/antheiz/)
 - [Symfony](https://github.com/jvl1v5/symfony-mazer) by [@jvl1v5](https://github.com/jvl1v5/)
+- [Symfony 6.3 (Mazer 2.1.0)](https://github.com/TheoD02/mazer-symfony-6.3/tree/mazer-2.1.0) by [@theod02](ttps://github.com/TheoD02)
 - [Spring-Thymeleaf](https://github.com/deyhay-enterprise/spring-project-mazer-template) by [@hi-rullah](https://github.com/hi-rullah)
 - [Ruby on Rails](https://github.com/noesya/mazer-rails) by [@noesya](https://github.com/noesya)
 - [Yii2](https://github.com/anovsiradj/yii2-theme-mazer) by [@anovsiradj](https://github.com/anovsiradj)


### PR DESCRIPTION
Hey

I purpose a Symfony with Webpack Encore with latest version of Symfony (6.3) that is currently in development (release planned to be in May 2023)

[Repository URL](https://github.com/TheoD02/mazer-symfony-6.3/tree/mazer-2.1.0)

All layouts it's implemented

Access to Front and Back controller ready to go
Error page are supported by default with App\Core\Http\Listener\ExceptionListener on kernel.exception Default locale in URL ready (fr/en by default)

No README for the moment, I will make it soon 👍