### PR TITLE
Issue, please fix: I recently discovered that there is a discrepancy …

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1067,11 +1067,11 @@ $zindex-dropdown:                   1000 !default;
 $zindex-sticky:                     1020 !default;
 $zindex-fixed:                      1030 !default;
 $zindex-offcanvas-backdrop:         1040 !default;
-$zindex-modal-backdrop:             1040 !default;
-$zindex-modal:                      1050 !default;
-$zindex-popover:                    1060 !default;
 $zindex-offcanvas:                  1045 !default;
-$zindex-tooltip:                    1070 !default;
+$zindex-modal-backdrop:             1050 !default;
+$zindex-modal:                      1055 !default;
+$zindex-popover:                    1070 !default;
+$zindex-tooltip:                    1080 !default;
 $zindex-toast:                      1090 !default;
 // scss-docs-end zindex-stack
 


### PR DESCRIPTION
I recently discovered that there is a discrepancy between the variables file of the Mazer project and the variables file of Bootstrap 5.3. This discrepancy cause an issue with the support of ng-bootstrap. When I use the modal window, the ngb-modal-backdrop obscures the ngb-modal-window. This is because the z-index of the backdrop is higher than the z-index of the window.

**ngb-modal-backdrop -> z-index 1055**
![backdrop](https://github.com/zuramai/mazer/assets/19518981/24d6aa9e-da01-4454-a18d-830ce9e74f3f)

**ngb-modal-window-> z-index 1050**
![image](https://github.com/zuramai/mazer/assets/19518981/ab6eae72-504c-4e7b-a447-d6d067faa8b5)


