### PR TITLE
current build default layout sidebar and main gets overlapped

### DIFF
--- a/src/assets/static/js/components/sidebar.js
+++ b/src/assets/static/js/components/sidebar.js
@@ -119,6 +119,7 @@ class Sidebar {
   onResize() {
     if (isDesktop(window)) {
       this.sidebarEL.classList.add("active")
+      this.sidebarEL.classList.remove("inactive")
     } else {
       this.sidebarEL.classList.remove("active")
     }


### PR DESCRIPTION
Current build default layout sidebar and main section gets overlapped when browser size gets small and the sidebar show button clicked then the browser size gets bigger again.