### PR TITLE
Fix Alert "close" button colors on dark/light backgrounds

### DIFF
--- a/src/assets/scss/components/_alert.scss
+++ b/src/assets/scss/components/_alert.scss
@@ -17,11 +17,11 @@
         }
     }
 }
-.alert-dark button.close{
+.alert-dark .btn-close{
     filter: $btn-close-white-filter;
 }
-.alert-secondary button.close,
-.alert-light button.close{
+.alert-secondary .btn-close,
+.alert-light .btn-close{
     @if($dark-mode == true) {
         filter: unset;
     }

--- a/src/assets/scss/components/_alert.scss
+++ b/src/assets/scss/components/_alert.scss
@@ -16,16 +16,15 @@
             margin-left: .4rem;
         }
     }
-    .alert-dark{
-        filter: var(--bs-btn-close-white-filter);
+}
+.alert-dark button.close{
+    filter: $btn-close-white-filter;
+}
+.alert-secondary button.close,
+.alert-light button.close{
+    @if($dark-mode == true) {
+        filter: unset;
     }
-    .alert-secondary,
-    .alert-light{
-        @if($dark-mode == true) {
-            filter: unset;
-        }
-    }
-    
 }
 @each $key, $value in $alert-colors {
     .alert-#{$key} {

--- a/src/assets/scss/components/_alert.scss
+++ b/src/assets/scss/components/_alert.scss
@@ -16,6 +16,16 @@
             margin-left: .4rem;
         }
     }
+    .alert-dark{
+        filter: var(--bs-btn-close-white-filter);
+    }
+    .alert-secondary,
+    .alert-light{
+        @if($dark-mode == true) {
+            filter: unset;
+        }
+    }
+    
 }
 @each $key, $value in $alert-colors {
     .alert-#{$key} {


### PR DESCRIPTION
This fixes a visual bug which made the "Close" button on dismissable alerts hard to see or invisible in some cases (e.g. the black X icon in the alert-dark component).

## Before:
- Light mode:
![screenshot](https://github.com/zuramai/mazer/assets/18481195/7ab9dcdb-63bf-47ee-a1e3-0dad8085068f)

- Dark mode:
![screenshot](https://github.com/zuramai/mazer/assets/18481195/b9919900-68a3-4d1e-bd98-017919554256)

## After:
- Light mode:
![screenshot](https://github.com/zuramai/mazer/assets/18481195/53f25bb0-15bd-48f2-8c52-ae7caded48bc)

- Dark mode:
![screenshot](https://github.com/zuramai/mazer/assets/18481195/44c9ba8d-6431-49f4-a36a-350fc1946d6b)

### Edit:
This doesn't seem to fully work yet... Any help is appreciated