### PR TITLE
Fix sweetalert2 input long size

### DIFF
--- a/src/assets/scss/pages/sweetalert2.scss
+++ b/src/assets/scss/pages/sweetalert2.scss
@@ -1,0 +1,3 @@
+.form-control {
+    width: initial;
+}

--- a/src/assets/scss/pages/sweetalert2.scss
+++ b/src/assets/scss/pages/sweetalert2.scss
@@ -1,3 +1,11 @@
-.form-control {
+.swal2-input.form-control {
+    width: initial;
+}
+
+.swal2-textarea.form-control {
+    width: initial;
+}
+
+.swal2-select.form-control {
     width: initial;
 }

--- a/src/extra-component-sweetalert.html
+++ b/src/extra-component-sweetalert.html
@@ -150,6 +150,7 @@
 </div>
 {% endblock %}
 {% block styles %}
+<link rel="stylesheet" href="assets/scss/pages/sweetalert2.scss">
 <link rel="stylesheet" href="assets/extensions/sweetalert2/sweetalert2.min.css">
 {% endblock %}
 {% block js %}


### PR DESCRIPTION
Hi, I have fixed a bug in sweetalert2 input. The bug is like the one in the screenshot. #268 
![Screenshot (73)](https://github.com/zuramai/mazer/assets/71764176/1580607e-c4ba-463e-8b30-ae27f73788c1)

The result is like this
![Screenshot (72)](https://github.com/zuramai/mazer/assets/71764176/bafb064b-49ac-4e11-b8e5-8b68d7a1705a)

What do I do?
1. Add a new scss file to the path `assets/scss/pages/sweetalert2.scss`
2. Change the width of the .form-control to the initial value