### PR TITLE
Fix pagination item border radius issue after bootstrap upate

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1220,7 +1220,7 @@ $pagination-color:                  $link-color !default;
 $pagination-bg:                     $white !default;
 $pagination-border-width:           $border-width !default;
 $pagination-border-radius:          $border-radius !default;
-$pagination-margin-start:           -$pagination-border-width !default;
+$pagination-margin-start:           calc(#{$pagination-border-width} * -1) !default;
 $pagination-border-color:           $gray-300 !default;
 
 $pagination-focus-color:            $link-hover-color !default;


### PR DESCRIPTION
Commit 809e8476 broke pagination styles due to changes in bootstraps SCSS.

New:
![image](https://github.com/zuramai/mazer/assets/1611565/18be74ec-a3e6-4e0f-a6bd-931a95d968cf)

Old:
![image](https://github.com/zuramai/mazer/assets/1611565/8520e5d7-063b-4b05-819a-063a3ca76710)

This happens because bootstrap adds border radius to each page link if it thinks the user intends to have margin between those elements:

```
  @if $pagination-margin-start == calc(#{$pagination-border-width} * -1) {
    ...
  } @else {
    // Add border-radius to all pageLinks in case they have left margin
    .page-link {
      @include border-radius(var(--#{$prefix}pagination-border-radius));
    }
  }
```

As the calc() is not executed on compile time, this comparison returns false for our value `$pagination-margin-start:           -$pagination-border-width !default;`

Setting `$pagination-margin-start` to the same calc() expression on our end restores the look.