### PR TITLE
Fix button colors in _variables.scss not being applied

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -88,7 +88,7 @@ $btn-colors: (
   info: (
       text-color: #000,
   ),
-);
+) !default;
 
 
 // Body

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1220,7 +1220,7 @@ $pagination-color:                  $link-color !default;
 $pagination-bg:                     $white !default;
 $pagination-border-width:           $border-width !default;
 $pagination-border-radius:          $border-radius !default;
-$pagination-margin-start:           -$pagination-border-width !default;
+$pagination-margin-start:           calc(#{$pagination-border-width} * -1) !default;
 $pagination-border-color:           $gray-300 !default;
 
 $pagination-focus-color:            $link-hover-color !default;

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -74,7 +74,7 @@ $btn-colors: (
       text-color: #fff,
   ),
   warning: (
-      text-color: #fff,
+      text-color: #000,
   ),
   danger: (
       text-color: #fff,
@@ -83,10 +83,10 @@ $btn-colors: (
       text-color: #fff,
   ),
   light: (
-      text-color: #818182,
+      text-color: #000,
   ),
   info: (
-      text-color: #fff,
+      text-color: #000,
   ),
 );
 

--- a/src/assets/scss/components/_buttons.scss
+++ b/src/assets/scss/components/_buttons.scss
@@ -40,7 +40,7 @@
     
     @each $key, $value in $btn-colors {
         &.btn-#{$key} {
-            color: map.get($btn-colors, "key", "text-color");
+            color: map.get($btn-colors, $key, "text-color");
         }
     }
 }


### PR DESCRIPTION
The button colors defined in `_variables.scss` are currently not applied due to a bug in `_buttons.scss`.
I fixed the bug in _buttons.scss and changed the colors set in _variables.scss to match the currently active colors, which are determined by bootstraps default functionality.

We should either adapt this change or remove the `btn-colors` sections from `_variables.scss` and `_buttons.scss`.